### PR TITLE
Add Jest testing for client utilities

### DIFF
--- a/Client/babel.config.cjs
+++ b/Client/babel.config.cjs
@@ -1,0 +1,5 @@
+module.exports = {
+  presets: [
+    ['@babel/preset-env', { targets: { node: 'current' } }],
+  ],
+};

--- a/Client/package.json
+++ b/Client/package.json
@@ -7,7 +7,8 @@
     "dev": "vite",
     "build": "vite build",
     "lint": "eslint . --ext js,jsx --report-unused-disable-directives --max-warnings 0",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "test": "jest"
   },
   "dependencies": {
     "@emotion/react": "^11.11.4",
@@ -33,6 +34,10 @@
     "eslint-plugin-react": "^7.33.2",
     "eslint-plugin-react-hooks": "^4.6.0",
     "eslint-plugin-react-refresh": "^0.4.5",
-    "vite": "^5.1.4"
+    "vite": "^5.1.4",
+    "jest": "^29.7.0",
+    "babel-jest": "^29.7.0",
+    "@babel/core": "^7.24.0",
+    "@babel/preset-env": "^7.24.0"
   }
 }

--- a/Client/src/Utils/__tests__/Formvalidation.test.js
+++ b/Client/src/Utils/__tests__/Formvalidation.test.js
@@ -1,0 +1,55 @@
+import { validateLoginForm, validateSignupForm } from '../Formvalidation.js';
+
+describe('validateLoginForm', () => {
+  test('returns errors for empty fields', () => {
+    const formData = { email: '', password: '' };
+    const { isValid, errors } = validateLoginForm(formData);
+    expect(isValid).toBe(false);
+    expect(errors).toEqual({
+      email: 'Email cannot be empty',
+      password: 'Password cannot be empty',
+    });
+  });
+
+  test('returns valid for correct data', () => {
+    const formData = { email: 'user@example.com', password: 'Password1' };
+    const { isValid, errors } = validateLoginForm(formData);
+    expect(isValid).toBe(true);
+    expect(errors).toEqual({});
+  });
+});
+
+describe('validateSignupForm', () => {
+  test('returns errors for invalid data', () => {
+    const formData = {
+      email: 'bad',
+      password: 'short',
+      name: '',
+      termsAccepted: false,
+      recaptchaToken: '',
+    };
+    const { isValid, errors } = validateSignupForm(formData);
+    expect(isValid).toBe(false);
+    expect(errors).toMatchObject({
+      email: 'Email is not valid',
+      password:
+        'Password must be at least 8 characters long and include at least one number, one lowercase and one uppercase letter.',
+      name: 'Name cannot be empty',
+      termsAccepted: 'You must accept the terms and conditions',
+      recaptchaToken: 'Please verify you are not a robot',
+    });
+  });
+
+  test('returns valid for all correct data', () => {
+    const formData = {
+      email: 'user@example.com',
+      password: 'Password1',
+      name: 'User',
+      termsAccepted: true,
+      recaptchaToken: 'token',
+    };
+    const { isValid, errors } = validateSignupForm(formData);
+    expect(isValid).toBe(true);
+    expect(errors).toEqual({});
+  });
+});

--- a/README.md
+++ b/README.md
@@ -1,1 +1,16 @@
 # SafetyApp
+
+## Running Client Tests
+
+Navigate to the `Client` directory and install dependencies if needed:
+
+```bash
+cd Client
+npm install
+```
+
+Run all Jest tests using:
+
+```bash
+npm test
+```


### PR DESCRIPTION
## Summary
- add Jest, Babel and related dev dependencies
- set up `npm test` script
- configure Babel for Jest
- add unit tests for `validateLoginForm` and `validateSignupForm`
- document how to run client tests

## Testing
- `npm install` *(fails: 403 Forbidden)*
- `npm test --silent` *(fails: jest: not found)*

------
https://chatgpt.com/codex/tasks/task_b_6842026b896c8325990da4b556e88272