### PR TITLE
Use SESSION_SECRET variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,16 @@
 # SafetyApp
+
+## Environment Variables
+
+Create a `.env` file in the `Server` directory with the following variables:
+
+```
+MONGO_URI=<your-mongodb-uri>
+SERVER_PORT=<port-to-run-the-server>
+BASE_SERVER_URL=<base-server-url>
+CLIENT_PORT=<client-port>
+SESSION_SECRET=<session-secret-key>
+```
+
+`SESSION_SECRET` is used by the server to sign session cookies. Make sure it is a
+strong, unique value.

--- a/Server/.env.example
+++ b/Server/.env.example
@@ -1,0 +1,5 @@
+MONGO_URI=your_mongo_connection_string
+SERVER_PORT=5000
+BASE_SERVER_URL=http://localhost
+CLIENT_PORT=5173
+SESSION_SECRET=your_session_secret

--- a/Server/server.js
+++ b/Server/server.js
@@ -58,7 +58,7 @@ mongoose.connect(process.env.MONGO_URI, {
 
 // Configure session middleware to use MongoDB for storage
 app.use(session({
-  secret: process.env.SESSION_SECERT,
+  secret: process.env.SESSION_SECRET,
   resave: false,
   saveUninitialized: false,
   store: MongoStore.create({ mongoUrl: process.env.MONGO_URI }),


### PR DESCRIPTION
## Summary
- use `SESSION_SECRET` in Express session config
- document server environment variables
- provide `.env.example` with `SESSION_SECRET`

## Testing
- `node server.js` *(fails: Cannot find package '/workspace/SafetyApp/Server/node_modules/express/index.js' imported from '/workspace/SafetyApp/Server/server.js')*

------
https://chatgpt.com/codex/tasks/task_b_6842026936fc8325b585e243b6ca7ff4